### PR TITLE
Add support ssh-copy-id to remote host other than 22 port

### DIFF
--- a/ansible_setup_passwordless_ssh.yml
+++ b/ansible_setup_passwordless_ssh.yml
@@ -101,7 +101,7 @@
     #     var: ssh_config_file_key_addition
 
     - name: distribute the ssh key to the remote hosts
-      shell: "sshpass -p \"{{remote_machine_password}}\" ssh-copy-id -o StrictHostKeyChecking=no -i ~/.ssh/{{ssh_key_filename}}.pub {{remote_machine_username}}@{{item}}"
+      shell: "/usr/local/bin/sshpass -p \"{{remote_machine_password}}\" ssh-copy-id -o StrictHostKeyChecking=no -i ~/.ssh/{{ssh_key_filename}}.pub -p {{ hostvars[item].ansible_port }} \"{{remote_machine_username}}@{{ hostvars[item].ansible_host }}\""
       register: ssh_copy_id_execution
       with_items: 
         - "{{ groups['ansible_setup_passwordless_setup_group']}}"

--- a/hosts
+++ b/hosts
@@ -8,5 +8,5 @@ remote_machine_password="xxxxxxxxxxxxxxxxxxxxxx"
 
 
 [ansible_setup_passwordless_setup_group]
-rhel-green
-rhel-red
+rhel-green ansible_port=22 ansible_user=root ansible_host=192.168.1.1
+rhel-red ansible_port=9022 ansible_user=root ansible_host=192.168.1.2


### PR DESCRIPTION
by adding extra parameter in host file and use ssh-copy-id -p {{ port }} to support the feature